### PR TITLE
Separated Auth initialisation from the base script

### DIFF
--- a/appwrite.json
+++ b/appwrite.json
@@ -232,8 +232,6 @@
     "buckets": [
         {
             "$id": "64a13095a4c87fd78bc6",
-            "$createdAt": "2023-07-02T08:08:53.675+00:00",
-            "$updatedAt": "2023-07-05T08:32:38.642+00:00",
             "$permissions": [
                 "create(\"any\")",
                 "read(\"any\")",
@@ -251,8 +249,6 @@
         },
         {
             "$id": "64a52ab306331f167ce6",
-            "$createdAt": "2023-07-05T08:32:51.026+00:00",
-            "$updatedAt": "2023-07-05T08:38:46.490+00:00",
             "$permissions": [
                 "create(\"any\")",
                 "read(\"any\")",
@@ -263,6 +259,23 @@
             "name": "user-images",
             "enabled": true,
             "maximumFileSize": 29000000,
+            "allowedFileExtensions": [],
+            "compression": "none",
+            "encryption": true,
+            "antivirus": true
+        },
+        {
+            "$id": "6703f4c70037edfd8429",
+            "$permissions": [
+                "create(\"any\")",
+                "read(\"any\")",
+                "update(\"any\")",
+                "delete(\"any\")"
+            ],
+            "fileSecurity": false,
+            "name": "stories",
+            "enabled": true,
+            "maximumFileSize": 30000000,
             "allowedFileExtensions": [],
             "compression": "none",
             "encryption": true,

--- a/appwrite.json
+++ b/appwrite.json
@@ -6,7 +6,7 @@
             "$id": "65368a58ef47cf6861200",
             "name": "Upcoming Rooms Time Checker",
             "runtime": "node-16.0",
-            "path": "functions/upcoming-Room-isTime-checker",
+            "path": "functions/upcomingRoom-isTime-checker",
             "entrypoint": "src/main.js",
             "ignore": [
                 "node_modules",
@@ -743,7 +743,12 @@
         },
         {
             "$id": "64a7bfe3a3a7ee5bf7f8",
-            "$permissions": [],
+            "$permissions": [
+                "create(\"any\")",
+                "read(\"any\")",
+                "update(\"any\")",
+                "delete(\"any\")"
+            ],
             "databaseId": "64a7bfd6b09121548bfe",
             "name": "OTP's",
             "enabled": true,
@@ -913,27 +918,159 @@
         },
         {
             "$id": "670259e20000ddda49a0",
-            "$permissions": [],
+            "$permissions": [
+                "create(\"any\")",
+                "read(\"any\")",
+                "update(\"any\")",
+                "delete(\"any\")"
+            ],
             "databaseId": "stories",
             "name": "Likes",
             "enabled": true,
             "documentSecurity": false,
-            "attributes": [],
-            "indexes": []
+            "attributes": [
+                {
+                    "key": "uId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 50,
+                    "default": null
+                },
+                {
+                    "key": "storyId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 50,
+                    "default": null
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "uId_index",
+                    "type": "key",
+                    "status": "available",
+                    "attributes": [
+                        "uId"
+                    ],
+                    "orders": [
+                        "ASC"
+                    ]
+                },
+                {
+                    "key": "storyId_index",
+                    "type": "key",
+                    "status": "available",
+                    "attributes": [
+                        "storyId"
+                    ],
+                    "orders": [
+                        "ASC"
+                    ]
+                }
+            ]
         },
         {
             "$id": "670277ad002530531daf",
-            "$permissions": [],
+            "$permissions": [
+                "create(\"any\")",
+                "read(\"any\")",
+                "update(\"any\")",
+                "delete(\"any\")"
+            ],
             "databaseId": "stories",
             "name": "Chapters",
             "enabled": true,
             "documentSecurity": false,
-            "attributes": [],
-            "indexes": []
+            "attributes": [
+                {
+                    "key": "title",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 20,
+                    "default": null
+                },
+                {
+                    "key": "description",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 2000,
+                    "default": null
+                },
+                {
+                    "key": "coverImgUrl",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "format": "url",
+                    "default": null
+                },
+                {
+                    "key": "lyrics",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 50000,
+                    "default": null
+                },
+                {
+                    "key": "totalMin",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 20,
+                    "default": null
+                },
+                {
+                    "key": "tintColor",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 20,
+                    "default": null
+                },
+                {
+                    "key": "storyId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 20,
+                    "default": null
+                },
+                {
+                    "key": "audioFileUrl",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "format": "url",
+                    "default": null
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "storyId_index",
+                    "type": "key",
+                    "status": "available",
+                    "attributes": [
+                        "storyId"
+                    ],
+                    "orders": [
+                        "ASC"
+                    ]
+                }
+            ]
         },
         {
             "$id": "670259e900321c12a5a2",
-            "$permissions": [],
+            "$permissions": [
+                "create(\"any\")",
+                "read(\"any\")",
+                "update(\"any\")",
+                "delete(\"any\")"
+            ],
             "databaseId": "stories",
             "name": "Stories",
             "enabled": true,
@@ -942,7 +1079,7 @@
                 {
                     "key": "title",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "size": 100,
                     "default": null
@@ -958,7 +1095,7 @@
                 {
                     "key": "category",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "elements": [
                         "dramma",
@@ -982,7 +1119,7 @@
                 {
                     "key": "creatorId",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "size": 50,
                     "default": null
@@ -990,7 +1127,7 @@
                 {
                     "key": "creatorName",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "size": 20,
                     "default": null
@@ -998,7 +1135,7 @@
                 {
                     "key": "creatorImgUrl",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "format": "url",
                     "default": null
@@ -1015,7 +1152,7 @@
                 {
                     "key": "totalMin",
                     "type": "string",
-                    "required": false,
+                    "required": true,
                     "array": false,
                     "size": 20,
                     "default": null

--- a/functions/verify-otp/src/main.js
+++ b/functions/verify-otp/src/main.js
@@ -31,7 +31,13 @@ export default async ({ req, res, log, error }) => {
             process.env.OTP_COLLECTION_ID,
             otpID
         );
+    } catch (e) {
+        log("error in getting the otp doc")
+        error(String(e));
+        return res.json({ message: String(e) }, 500);
+    }
 
+    try {
         await db.createDocument(
             process.env.VERIFICATION_DATABASE_ID,
             process.env.VERIFY_COLLECTION_ID,
@@ -41,9 +47,9 @@ export default async ({ req, res, log, error }) => {
             }
         );
     } catch (e) {
+        log("error in creating the verification doc")
         error(String(e));
         return res.json({ message: String(e) }, 500);
     }
-
     return res.json({ message: 'null' }, 200);
 };

--- a/init-auth.ps1
+++ b/init-auth.ps1
@@ -1,0 +1,69 @@
+# Rn this file contains chunks of commands that could help get the auth initialisation set up quickily
+
+
+# Write-Host "Installing devtunnels"
+
+# Invoke-WebRequest -Uri https://aka.ms/TunnelsCliDownload/win-x64 -OutFile devtunnel.exe
+# .\devtunnel.exe -h
+
+# while ($true) {
+#     devtunnel login
+#     if ($LASTEXITCODE -eq 0) {
+#         break
+#     } else {
+#         Write-Host "devtunnel login failed. Please try again."
+#     }
+# }
+
+# function Check-Status {
+#     param ($processName)
+
+#     if ($LASTEXITCODE -ne 0) {
+#         Write-Host "Error: $processName failed to start. Exiting script."
+#         exit 1
+#     }
+# }
+
+# # Start the first devtunnel on port 80
+# Write-Host "Starting devtunnel on port 80..."
+# Start-Process "devtunnel" -ArgumentList "host -p 80 --allow-anonymous --protocol http --host-header unchanged" -NoNewWindow -RedirectStandardOutput $null -RedirectStandardError $null
+# Start-Sleep -Seconds 2
+# Check-Status "devtunnel on port 80"
+
+# # Start the second devtunnel on port 7880
+# Write-Host "Starting devtunnel on port 7880..."
+# Start-Process "devtunnel" -ArgumentList "host -p 7880 --allow-anonymous --protocol http --host-header unchanged" -NoNewWindow -RedirectStandardOutput $null -RedirectStandardError $null
+# Start-Sleep -Seconds 2
+# Check-Status "devtunnel on port 7880"
+
+# Write-Host "Both devtunnels started successfully."
+
+# # Get the list of active tunnels and extract the URLs
+# Write-Host "Fetching the list of active tunnels"
+# $tunnel_list = devtunnel list
+
+# Write-Host $tunnel_list
+
+# # Extract tunnel IDs from the list
+# $tunnel_ids = $tunnel_list -match '\b[a-z0-9-]*\.inc1\b' | ForEach-Object { $_.Matches.Value }
+
+# # Split the IDs into individual variables if needed
+# $tunnel_id_1 = $tunnel_ids[0]
+# $tunnel_id_2 = $tunnel_ids[1]
+
+# # Output the extracted tunnel IDs
+# Write-Host "Tunnel ID for Appwrite: $tunnel_id_1"
+# Write-Host "Tunnel ID for Livekit: $tunnel_id_2"
+
+
+# Ask contributor for Oauth2 provider config (Google. Github)
+# Write-Host "Please follow the Set Up Guide on Resonate to create the Oauth2 credentials for Google and Github"
+
+# Write-Host "ngrok tunnel Domain Name: $ngrok_url"
+# $googleAppId = Read-Host "Enter the Google App ID"
+# $googleSecret = Read-Host "Enter the Google App Secret"
+# appwrite projects update-o-auth-2 --project-id $projectId --provider 'google' --appId $googleAppId --secret $googleSecret --enabled $true
+
+# $githubAppId = Read-Host "Enter the GitHub App ID"
+# $githubSecret = Read-Host "Enter the GitHub App Secret"
+# appwrite projects update-o-auth-2 --project-id $projectId --provider 'github' --appId $githubAppId --secret $githubSecret --enabled $true

--- a/init-auth.sh
+++ b/init-auth.sh
@@ -1,0 +1,69 @@
+# Rn this file contains chunks of commands that could help get the auth initialisation set up quickily
+
+## Install devtunnel command for macOS
+# brew install --cask devtunnel
+
+# Install devtunnel command for linux
+# curl -sL https://aka.ms/DevTunnelCliInstall | bash
+
+## Devtunnel login command
+# while true; do
+#     devtunnel login
+#     if [ $? -eq 0 ]; then
+#         break
+#     else
+#         echo "devtunnel login failed. Please try again."
+#     fi
+# done
+
+
+
+## Start Devtunnels and get the Url's
+# check_status() {
+#     if [ $? -ne 0 ]; then
+#         echo "Error: $1 failed to start. Exiting script."
+#         exit 1
+#     fi
+# }
+# Start the first devtunnel on port 80
+# echo "Starting devtunnel on port 80..."
+# devtunnel host -p 80 --allow-anonymous --protocol http --host-header unchanged > /dev/null 2>&1 &
+# check_status "devtunnel on port 80"
+
+# # Start the second devtunnel on port 7880
+# echo "Starting devtunnel on port 7880..."
+# devtunnel host -p 7880 --allow-anonymous --protocol http --host-header unchanged > /dev/null 2>&1 &
+# check_status "devtunnel on port 7880"
+
+# sleep 2
+
+# echo "Both devtunnels started successfully."
+
+# Get the list of active tunnels and extract the URLs
+# echo "Fetching the list of active tunnels"
+# tunnel_list=$(devtunnel list)
+
+# echo $tunnel_list
+# tunnel_ids=$(echo "$tunnel_list" | grep -o '\b[a-z0-9-]*\.inc1\b')
+
+# # Split the IDs into individual variables if needed
+# tunnel_id_1=$(echo "$tunnel_ids" | sed -n '1p')
+# tunnel_id_2=$(echo "$tunnel_ids" | sed -n '2p')
+
+# # Output the extracted tunnel IDs
+# echo "Tunnel ID for Appwrite: $tunnel_id_1"
+# echo "Tunnel ID for Livekit: $tunnel_id_2"
+
+
+## Start initialising Auth
+
+# Ask contributor for Oauth2 provider config (Google. Github)
+# echo "Please follow the Set Up Guide on Resonate to create the Oauth2 credentials for Google and Github"
+
+# read -p "Enter the Google App ID: " googleAppId
+# read -p "Enter the Google App Secret: " googleSecret
+# appwrite projects update-o-auth-2 --project-id "$projectId" --provider 'google' --appId "$googleAppId" --secret "$googleSecret" --enabled true
+
+# read -p "Enter the GitHub App ID: " githubAppId
+# read -p "Enter the GitHub App Secret: " githubSecret
+# appwrite projects update-o-auth-2 --project-id "$projectId" --provider 'github' --appId "$githubAppId" --secret "$githubSecret" --enabled true

--- a/init.ps1
+++ b/init.ps1
@@ -50,63 +50,6 @@ while ($true) {
     }
 }
 
-# start ngrok tunnel
-Write-Host "Installing devtunnels"
-
-Invoke-WebRequest -Uri https://aka.ms/TunnelsCliDownload/win-x64 -OutFile devtunnel.exe
-.\devtunnel.exe -h
-
-while ($true) {
-    devtunnel login
-    if ($LASTEXITCODE -eq 0) {
-        break
-    } else {
-        Write-Host "devtunnel login failed. Please try again."
-    }
-}
-
-function Check-Status {
-    param ($processName)
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Error: $processName failed to start. Exiting script."
-        exit 1
-    }
-}
-
-# Start the first devtunnel on port 80
-Write-Host "Starting devtunnel on port 80..."
-Start-Process "devtunnel" -ArgumentList "host -p 80 --allow-anonymous --protocol http --host-header unchanged" -NoNewWindow -RedirectStandardOutput $null -RedirectStandardError $null
-Start-Sleep -Seconds 2
-Check-Status "devtunnel on port 80"
-
-# Start the second devtunnel on port 7880
-Write-Host "Starting devtunnel on port 7880..."
-Start-Process "devtunnel" -ArgumentList "host -p 7880 --allow-anonymous --protocol http --host-header unchanged" -NoNewWindow -RedirectStandardOutput $null -RedirectStandardError $null
-Start-Sleep -Seconds 2
-Check-Status "devtunnel on port 7880"
-
-Write-Host "Both devtunnels started successfully."
-
-# Get the list of active tunnels and extract the URLs
-Write-Host "Fetching the list of active tunnels"
-$tunnel_list = devtunnel list
-
-Write-Host $tunnel_list
-
-# Extract tunnel IDs from the list
-$tunnel_ids = $tunnel_list -match '\b[a-z0-9-]*\.inc1\b' | ForEach-Object { $_.Matches.Value }
-
-# Split the IDs into individual variables if needed
-$tunnel_id_1 = $tunnel_ids[0]
-$tunnel_id_2 = $tunnel_ids[1]
-
-# Output the extracted tunnel IDs
-Write-Host "Tunnel ID for Appwrite: $tunnel_id_1"
-Write-Host "Tunnel ID for Livekit: $tunnel_id_2"
-
-
-
 Write-Host "Starting resonate project set up...."
 # Get team id for project creation
 $teamId = Read-Host "Please provide the team Id as instructed in the Resonate Set Up Guide"
@@ -130,24 +73,13 @@ appwrite project create-variable --key APPWRITE_API_KEY --value $secret
 # Push endpoint as environment variable for functions to use (host.docker.internal used to access localhost from inside of script)
 appwrite project create-variable --key APPWRITE_ENDPOINT --value "http://host.docker.internal:80/v1"
 
-# Ask contributor for Oauth2 provider config (Google. Github)
-Write-Host "Please follow the Set Up Guide on Resonate to create the Oauth2 credentials for Google and Github"
-
-Write-Host "ngrok tunnel Domain Name: $ngrok_url"
-$googleAppId = Read-Host "Enter the Google App ID"
-$googleSecret = Read-Host "Enter the Google App Secret"
-appwrite projects update-o-auth-2 --project-id $projectId --provider 'google' --appId $googleAppId --secret $googleSecret --enabled $true
-
-$githubAppId = Read-Host "Enter the GitHub App ID"
-$githubSecret = Read-Host "Enter the GitHub App Secret"
-appwrite projects update-o-auth-2 --project-id $projectId --provider 'github' --appId $githubAppId --secret $githubSecret --enabled $true
-
 # Pushing the project's core defined in appwrite.json
 appwrite deploy collection
 appwrite deploy function
 appwrite deploy bucket
-
 Write-Host "---- Appwrite Set Up complete ----"
+
+
 Write-Host "Setting Up Livekit now ..."
 # Push Livekit credentials as env variables for functions to use
 while ($true) {

--- a/init.sh
+++ b/init.sh
@@ -17,69 +17,20 @@ if [ "$OS_TYPE" = "Mac" ]; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     brew install appwrite
     brew install livekit
-    brew install --cask devtunnel
+
     brew install livekit-cli
 else
     curl -sL https://appwrite.io/cli/install.sh | bash
     curl -sSL https://get.livekit.io | bash
-    curl -sL https://aka.ms/DevTunnelCliInstall | bash
     curl -sSL https://get.livekit.io/cli | bash
 fi
-
-
-while true; do
-    devtunnel login
-    if [ $? -eq 0 ]; then
-        break
-    else
-        echo "devtunnel login failed. Please try again."
-    fi
-done
-
-
-check_status() {
-    if [ $? -ne 0 ]; then
-        echo "Error: $1 failed to start. Exiting script."
-        exit 1
-    fi
-}
-
-# Start the first devtunnel on port 80
-echo "Starting devtunnel on port 80..."
-devtunnel host -p 80 --allow-anonymous --protocol http --host-header unchanged > /dev/null 2>&1 &
-check_status "devtunnel on port 80"
-
-# Start the second devtunnel on port 7880
-echo "Starting devtunnel on port 7880..."
-devtunnel host -p 7880 --allow-anonymous --protocol http --host-header unchanged > /dev/null 2>&1 &
-check_status "devtunnel on port 7880"
-
-sleep 2
-
-echo "Both devtunnels started successfully."
-
-# Get the list of active tunnels and extract the URLs
-echo "Fetching the list of active tunnels"
-tunnel_list=$(devtunnel list)
-
-echo $tunnel_list
-tunnel_ids=$(echo "$tunnel_list" | grep -o '\b[a-z0-9-]*\.inc1\b')
-
-# Split the IDs into individual variables if needed
-tunnel_id_1=$(echo "$tunnel_ids" | sed -n '1p')
-tunnel_id_2=$(echo "$tunnel_ids" | sed -n '2p')
-
-# Output the extracted tunnel IDs
-echo "Tunnel ID for Appwrite: $tunnel_id_1"
-echo "Tunnel ID for Livekit: $tunnel_id_2"
 
 
 docker run -it --add-host host.docker.internal:host-gateway --rm \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
     --entrypoint="install" \
-    appwrite/appwrite:latest
-
+    appwrite/appwrite:1.6.0
 
 projectId="resonate"
 
@@ -124,28 +75,14 @@ appwrite project create-variable --key APPWRITE_API_KEY --value "$secret"
 # Push endpoint as environment variable for functions to use (host.docker.internal used to access localhost from inside of script)
 appwrite project create-variable --key APPWRITE_ENDPOINT --value "http://host.docker.internal:80/v1"
 
-
-
-# Ask contributor for Oauth2 provider config (Google. Github)
-echo "Please follow the Set Up Guide on Resonate to create the Oauth2 credentials for Google and Github"
-
-echo "ngrok tunnel Domain Name: $ngrok_url"
-read -p "Enter the Google App ID: " googleAppId
-read -p "Enter the Google App Secret: " googleSecret
-appwrite projects update-o-auth-2 --project-id "$projectId" --provider 'google' --appId "$googleAppId" --secret "$googleSecret" --enabled true
-
-read -p "Enter the GitHub App ID: " githubAppId
-read -p "Enter the GitHub App Secret: " githubSecret
-appwrite projects update-o-auth-2 --project-id "$projectId" --provider 'github' --appId "$githubAppId" --secret "$githubSecret" --enabled true
-
 # Pushing the project's core defined in appwrite.json
 appwrite push collection
 appwrite push function
 appwrite push bucket
-
 echo "---- Appwrite Set Up complete ----"
+
+
 echo "Setting Up Livekit now ..."
-# Push Livekit credentials as env variables for functions to use
 while true; do
     read -p "Do you wish to opt for Livekit Cloud or Host Livekit locally? For Locally: y, For Cloud: n (y/n)" isLocalDeployment
     if [[ $isLocalDeployment == "y" || $isLocalDeployment == "Y" ]]; then
@@ -191,6 +128,3 @@ appwrite project create-variable --key LIVEKIT_HOST --value "$livekitHostURL"
 appwrite project create-variable --key LIVEKIT_SOCKET_URL --value "$livekitSocketURL"
 appwrite project create-variable --key LIVEKIT_API_KEY --value "$livekitAPIKey"
 dcreate-variable --key LIVEKIT_API_SECRET --value "$livekitAPISecret"
-
-echo "Tunnel ID for Appwrite: $tunnel_id_1"
-echo "Tunnel ID for Livekit: $tunnel_id_2"


### PR DESCRIPTION
Google auth does not allow private IP so we had to provide a tunneling solution to allow initialisation of auth.

We used devtunnels after a lot of research. But tunneling was heavy and as many company and University private networks do not support it a lot of contributors were having issues with them and as we were tunneling in the main script we used to tunnel to operate appwrite in the entire project it caused the robustness of the script to fall levels below and now become a challenege to run the backend env using it 

So separating the auth initialisation provides the robust stature of the script back to it now anyone should be able to run the backend using the script to the extent that they can fully experience all the functionality of the app except the auth with Oauth providers