### PR TITLE
Updated Appwrite-cli scoop installation command

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -29,7 +29,7 @@ else {
 
 
 Write-Host "Install Appwrite-cli using Scoop"
-scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/scoop/appwrite.json
+scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/scoop/appwrite.config.json
 
 docker run -it --add-host host.docker.internal:host-gateway --rm `
     --volume /var/run/docker.sock:/var/run/docker.sock `


### PR DESCRIPTION
### **Installation Command Update Needed**

#### **Error Causing**
<img width="1509" height="100" alt="image" src="https://github.com/user-attachments/assets/b7438fc1-202e-4ff6-9860-43a0d9460505" />

### **Solution**
The Appwrite-cli scoop installation command is updated :-

_**from**_

```
scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/scoop/appwrite.json
```

_**to**_
```
scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/scoop/appwrite.config.json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Appwrite CLI installation source to the latest configuration, preventing setup failures and ensuring a smoother install experience. All other checks and setup steps remain unchanged.

* **Chores**
  * Updated the installer configuration reference to stay aligned with upstream changes, maintaining compatibility without altering existing workflow or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->