### PR TITLE
Refactor async handling in cleanParticipantsCollection to prevent race conditions and ensure reliable participant cleanup

### DIFF
--- a/functions/database-cleaner/src/appwrite.js
+++ b/functions/database-cleaner/src/appwrite.js
@@ -35,13 +35,13 @@ class AppwriteService {
         );
 
         await Promise.all(
-            participantDocs.documents.map(async(participantDocs)=>{
+            participantDocs.documents.map(async(participantDoc)=>{
                 try{
-                    if(!(await this.doesRoomExist(participantDocs.roomId))){
+                    if(!(await this.doesRoomExist(participantDoc.roomId))){
                         await this.databases.deleteDocument(
                             process.env.MASTER_DATABASE_ID,
-                            process.env/PARTICIPANTS_COLLECTION_ID,
-                            participantDocs.$id
+                            process.env.PARTICIPANTS_COLLECTION_ID,
+                            participantDoc.$id
                         );
                     }
                 }catch(error){

--- a/functions/database-cleaner/src/appwrite.js
+++ b/functions/database-cleaner/src/appwrite.js
@@ -34,15 +34,21 @@ class AppwriteService {
             process.env.PARTICIPANTS_COLLECTION_ID
         );
 
-        participantDocs.documents.forEach(async (participantDoc) => {
-            if (!(await this.doesRoomExist(participantDoc.roomId))) {
-                await this.databases.deleteDocument(
-                    process.env.MASTER_DATABASE_ID,
-                    process.env.PARTICIPANTS_COLLECTION_ID,
-                    participantDoc.$id
-                );
-            }
-        });
+        await Promise.all(
+            participantDocs.documents.map(async(participantDocs)=>{
+                try{
+                    if(!(await this.doesRoomExist(participantDocs.roomId))){
+                        await this.databases.deleteDocument(
+                            process.env.MASTER_DATABASE_ID,
+                            process.env/PARTICIPANTS_COLLECTION_ID,
+                            participantDocs.$id
+                        );
+                    }
+                }catch(error){
+                    console.error(`Failed to clean participant ${participantDoc.$id}:`, error);
+                }
+            })
+        );
     }
 
     async cleanActivePairsCollection() {


### PR DESCRIPTION
The `cleanParticipantsCollection` method previously used `forEach` with asynchronous callbacks to delete participant records whose associated rooms no longer exist. This approach led to race conditions and unreliable cleanup, as `forEach` does not await async operations, causing the method to return before all deletions were completed and errors to be silently ignored.

---

### **What Was Wrong Before**

- Used `forEach` with async callbacks, which does not wait for completion of asynchronous operations.
- The method could return before all deletions finished, leading to incomplete cleanup.
- Errors during deletion were not properly handled or logged.
- Potential for data inconsistency and silent failures in production.

---

### **What Has Been Fixed**

- Replaced `forEach` with `Promise.all` and `map` to ensure all deletions are awaited.
- Added robust error handling and logging for failed deletions.
- Improved variable naming for clarity.
- Corrected a typo in the environment variable reference (`process.env/PARTICIPANTS_COLLECTION_ID` to `process.env.PARTICIPANTS_COLLECTION_ID`).

---

### **Impact**

- Ensures reliable and complete cleanup of participant records.
- Prevents race conditions and silent failures.
- Enhances data integrity and maintainability of the codebase.
- Aligns with best practices for asynchronous operations in Node.js.

---

This PR fixes issue #109.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Background cleanup now runs participant removals in parallel for faster completion.
  - Per-item async handling added to isolate failures and skip removals when related records are missing.

- **Bug Fixes**
  - Reduced intermittent cleanup failures by logging individual errors without aborting the overall process, improving stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->