### PR TITLE
Add email (OTP) credentials setup to init scripts

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -75,9 +75,17 @@ Write-Host "Extracted secret: $secret"
 
 # Pushing Server Key as env variable for cloud functions to use
 appwrite project create-variable --key APPWRITE_API_KEY --value $secret
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set APPWRITE_API_KEY"
+    exit 1
+}
 
 # Push endpoint as environment variable for functions to use (host.docker.internal used to access localhost from inside of script)
 appwrite project create-variable --key APPWRITE_ENDPOINT --value "http://host.docker.internal:80/v1"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set APPWRITE_ENDPOINT"
+    exit 1
+}
 
 # Pushing the project's core defined in appwrite.json
 appwrite push collections
@@ -135,7 +143,16 @@ while ($true) {
 # Push MeiliSearch credentials as env variables for functions to use
 Write-Host "Pushing MeiliSearch credentials as env variables if you need any changes do them in your Appwrite Resonate project's Global Env variables"
 appwrite project create-variable --key MEILISEARCH_ENDPOINT --value $meilisearchEndpoint
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set MEILISEARCH_ENDPOINT"
+    exit 1
+}
+
 appwrite project create-variable --key MEILISEARCH_ADMIN_API_KEY --value $meilisearchMasterKey
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set MEILISEARCH_ADMIN_API_KEY"
+    exit 1
+}
 
 
 Write-Host "Setting Up Livekit now ..."
@@ -183,7 +200,80 @@ while ($true) {
 # Push Livekit credentials as env variables for functions to use
 Write-Host "Pushing Livekit credentials as env variables if you need any changes do them in your Appwrite Resonate project's Global Env variables"
 appwrite project create-variable --key LIVEKIT_HOST --value $livekitHostURL
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set LIVEKIT_HOST"
+    exit 1
+}
+
 appwrite project create-variable --key LIVEKIT_SOCKET_URL --value $livekitSocketURL
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set LIVEKIT_SOCKET_URL"
+    exit 1
+}
+
 appwrite project create-variable --key LIVEKIT_API_KEY --value $livekitAPIKey
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set LIVEKIT_API_KEY"
+    exit 1
+}
+
 appwrite project create-variable --key LIVEKIT_API_SECRET --value $livekitAPISecret
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set LIVEKIT_API_SECRET"
+    exit 1
+}
+
+Write-Host "Setting up Email (OTP) now ..."
+Write-Host "This email will be used to send OTP verification codes to users."
+
+# Input validation loop for sender email
+do {
+    $senderMail = Read-Host "Please provide sender email address (e.g., your-email@gmail.com)"
+} while ([string]::IsNullOrWhiteSpace($senderMail))
+
+# Input validation loop for sender password
+do {
+    $senderPassword = Read-Host "Please provide sender email app password" -AsSecureString
+    # Check if password is empty by converting temporarily
+    $bstrTemp = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($senderPassword)
+    try {
+        $tempPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstrTemp)
+        $isEmpty = [string]::IsNullOrWhiteSpace($tempPlain)
+    } finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstrTemp)
+    }
+    
+    if ($isEmpty) {
+        Write-Host "Password cannot be empty. Please try again."
+    }
+} while ($isEmpty)
+
+# Convert SecureString to plain text with proper cleanup
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($senderPassword)
+try {
+    $senderPasswordPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    
+    # Push email credentials as environment variables
+    Write-Host "Pushing Email credentials as env variables..."
+    
+    appwrite project create-variable --key SENDER_MAIL --value $senderMail
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to set SENDER_MAIL"
+        exit 1
+    }
+    
+    appwrite project create-variable --key SENDER_PASSWORD --value $senderPasswordPlain
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to set SENDER_PASSWORD"
+        exit 1
+    }
+    
+    Write-Host "Email credentials configured successfully!"
+} finally {
+    # Clean up sensitive memory
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+
 appwrite push functions --with-variables
+
+Write-Host "Many Congratulations! Resonate Backend set up is complete!!! Please further read the onboarding guide for connecting frontend to backend"

--- a/init.sh
+++ b/init.sh
@@ -174,6 +174,26 @@ appwrite project create-variable --key LIVEKIT_HOST --value "$livekitHostURL"
 appwrite project create-variable --key LIVEKIT_SOCKET_URL --value "$livekitSocketURL"
 appwrite project create-variable --key LIVEKIT_API_KEY --value "$livekitAPIKey"
 appwrite project create-variable --key LIVEKIT_API_SECRET --value "$livekitAPISecret"
+
+while true; do
+    read -p "Please provide sender email address (e.g., your-email@gmail.com): " senderMail
+    if [[ ! -z "$senderMail" ]]; then
+        break
+    fi
+done
+
+while true; do
+    read -sp "Please provide sender email app password: " senderPassword
+    echo
+    if [[ ! -z "$senderPassword" ]]; then
+        break
+    fi
+done
+
+appwrite project create-variable --key SENDER_MAIL --value "$senderMail" || { echo "Failed to set SENDER_MAIL"; exit 1; }
+appwrite project create-variable --key SENDER_PASSWORD --value "$senderPassword" || { echo "Failed to set SENDER_PASSWORD"; exit 1; }
+echo "Email credentials configured successfully!"
+
 appwrite push functions --with-variables
 
 echo "Many Congratulations Resonate Backend set up is complete !!! please further read the onboarding guide for connecting frontend to backend"


### PR DESCRIPTION
**Changes Made**

Added email setup section in init.sh and init.ps1, and Added prompts for sender email and app password during initialization.
Configured the credentials to be stored as project environment variables.
Followed the existing structure used for MeiliSearch and Livekit setup.

**Testing**

Verified that email credentials are prompted and stored correctly.
Confirmed that the initialization flow remains smooth and consistent.
Ensured no regressions or breaking changes in existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email (OTP) setup integrated into initialization: prompts for sender email and app password, securely captures and stores credentials.

* **Chores**
  * Enhanced initialization workflow and Livekit credential prompts for clearer setup.
  * Added robust failure checks during environment-variable pushes and a final success message after setup completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->