### PR TITLE
chore: add .caddy.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ appwrite/
 **/node_modules/
 **/resonate-service-account.json
 meili_data/
+.caddy.log


### PR DESCRIPTION
Fixes #121 
## Summary

This PR updates the `.gitignore` to exclude the Caddy log file (`.caddy.log`) from version control.

## What I changed

- Added `.caddy.log` to `.gitignore` so that Caddy-generated logs are not tracked by Git.
- (If applicable) Removed any existing `.caddy.log` file from Git tracking.

## Why this is needed

- `.caddy.log` is a generated log file and should not be committed to the repository.
- Ignoring this file:
  - Keeps the repo clean and focused on source code
  - Prevents unnecessary noise in commits and diffs
  - Avoids accidentally committing large or machine-specific log content

## Notes

- This change does **not** affect application behavior or runtime logic.
- It only impacts which files are tracked by Git.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore file with minor configuration adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->