### PR TITLE
Add CODEOWNERS file to backend repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for Resonate Backend
+* @M4dhav


### PR DESCRIPTION
## Description

This PR adds a `.github/CODEOWNERS` file to the Resonate Backend repository to define default code owners.

Having a CODEOWNERS file enables GitHub to automatically request reviews from maintainers on every pull request, improving review workflow, accountability, and long-term maintainability.

Fixes #144 

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality)
- [ ] Documentation update
- [ ] New release
- [ ] UI/UX update
- [x] CI/CD & Tooling
- [ ] Dependency update

---

## How Has This Been Tested?

This change does not affect runtime behavior.

Verified that the `CODEOWNERS` file is placed under the `.github/` directory as per GitHub best practices and is recognized for automatic reviewer assignment.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally

---

## Maintainer Checklist

- [x] Closes #144 
- [x] Tag the PR with appropriate labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub CODEOWNERS configuration file for repository code ownership management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->