### PR TITLE
Add CODEOWNERS file to define repository maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @M4dhav
+
+.github/CODEOWNERS @AOSSIE-Org/maintainers


### PR DESCRIPTION
fixes #144 
This PR introduces a CODEOWNERS file to clearly define code ownership across the repository. With this addition, pull requests will automatically request reviews from the appropriate maintainers, helping improve review efficiency and long-term maintainability. 

@M4dhav please review this 