### PR TITLE
feat: add CODEOWNERS file to define repository maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @M4dhav
+
+.github/CODEOWNERS @AOSSIE-Org/maintainers


### PR DESCRIPTION
Fixes #144 

This PR adds a CODEOWNERS file to the repository to clearly define ownership for different parts of the codebase. With this in place, GitHub can automatically request reviews from the appropriate maintainers whenever changes are made. This improves the pull request review workflow, increases accountability, and helps maintain code quality. No functional or behavioral changes are introduced as part of this update.

@M4dhav  please review 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration to designate project maintainers and establish clear code review responsibilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->