### PR TITLE
fix : ensured atomic room deletion and fix orphaned data.

### DIFF
--- a/functions/database-cleaner/src/appwrite.js
+++ b/functions/database-cleaner/src/appwrite.js
@@ -29,27 +29,41 @@ class AppwriteService {
     }
 
     async cleanParticipantsCollection() {
-        const participantDocs = await this.databases.listDocuments(
-            process.env.MASTER_DATABASE_ID,
-            process.env.PARTICIPANTS_COLLECTION_ID,
-            [Query.limit(100)]
-        );
+        let done = false;
+        let lastId = null;
+        while (!done) {
+            const queries = [Query.limit(50)];
+            if (lastId) {
+                queries.push(Query.cursorAfter(lastId));
+            }
 
-        await Promise.all(
-            participantDocs.documents.map(async (participantDoc) => {
-                if (!(await this.doesRoomExist(participantDoc.roomId))) {
-                    try {
-                        await this.databases.deleteDocument(
-                            process.env.MASTER_DATABASE_ID,
-                            process.env.PARTICIPANTS_COLLECTION_ID,
-                            participantDoc.$id
-                        );
-                    } catch (err) {
-                        if (err.code !== 404) throw err;
-                    }
-                }
-            })
-        );
+            const participantDocs = await this.databases.listDocuments(
+                process.env.MASTER_DATABASE_ID,
+                process.env.PARTICIPANTS_COLLECTION_ID,
+                queries
+            );
+
+            if (participantDocs.documents.length > 0) {
+                await Promise.all(
+                    participantDocs.documents.map(async (participantDoc) => {
+                        if (!(await this.doesRoomExist(participantDoc.roomId))) {
+                            try {
+                                await this.databases.deleteDocument(
+                                    process.env.MASTER_DATABASE_ID,
+                                    process.env.PARTICIPANTS_COLLECTION_ID,
+                                    participantDoc.$id
+                                );
+                            } catch (err) {
+                                if (err.code !== 404) throw err;
+                            }
+                        }
+                    })
+                );
+                lastId = participantDocs.documents[participantDocs.documents.length - 1].$id;
+            } else {
+                done = true;
+            }
+        }
     }
 
     async cleanActivePairsCollection() {

--- a/functions/database-cleaner/src/appwrite.js
+++ b/functions/database-cleaner/src/appwrite.js
@@ -31,18 +31,25 @@ class AppwriteService {
     async cleanParticipantsCollection() {
         const participantDocs = await this.databases.listDocuments(
             process.env.MASTER_DATABASE_ID,
-            process.env.PARTICIPANTS_COLLECTION_ID
+            process.env.PARTICIPANTS_COLLECTION_ID,
+            [Query.limit(100)]
         );
 
-        participantDocs.documents.forEach(async (participantDoc) => {
-            if (!(await this.doesRoomExist(participantDoc.roomId))) {
-                await this.databases.deleteDocument(
-                    process.env.MASTER_DATABASE_ID,
-                    process.env.PARTICIPANTS_COLLECTION_ID,
-                    participantDoc.$id
-                );
-            }
-        });
+        await Promise.all(
+            participantDocs.documents.map(async (participantDoc) => {
+                if (!(await this.doesRoomExist(participantDoc.roomId))) {
+                    try {
+                        await this.databases.deleteDocument(
+                            process.env.MASTER_DATABASE_ID,
+                            process.env.PARTICIPANTS_COLLECTION_ID,
+                            participantDoc.$id
+                        );
+                    } catch (err) {
+                        if (err.code !== 404) throw err;
+                    }
+                }
+            })
+        );
     }
 
     async cleanActivePairsCollection() {

--- a/functions/delete-room/src/main.js
+++ b/functions/delete-room/src/main.js
@@ -50,25 +50,36 @@ export default async ({ req, res, log, error }) => {
             return res.json({ msg: "User is not room admin" }, 403);
         }
 
-        // 1. Removing participants from collection
-        const participantColRef = await databases.listDocuments(
-            process.env.MASTER_DATABASE_ID,
-            process.env.PARTICIPANTS_COLLECTION_ID,
-            [Query.equal("roomId", [appwriteRoomDocId])]
-        );
-        
-        log(`Found ${participantColRef.documents.length} participants to remove.`);
-        
-        if (participantColRef.documents.length > 0) {
-            await Promise.all(
-                participantColRef.documents.map((participant) =>
-                    databases.deleteDocument(
-                        process.env.MASTER_DATABASE_ID,
-                        process.env.PARTICIPANTS_COLLECTION_ID,
-                        participant.$id
-                    )
-                )
+        // 1. Removing participants from collection (with pagination)
+        let participantsDone = false;
+        while (!participantsDone) {
+            const participantColRef = await databases.listDocuments(
+                process.env.MASTER_DATABASE_ID,
+                process.env.PARTICIPANTS_COLLECTION_ID,
+                [
+                    Query.equal("roomId", [appwriteRoomDocId]),
+                    Query.limit(50)
+                ]
             );
+
+            if (participantColRef.documents.length > 0) {
+                log(`Removing ${participantColRef.documents.length} participants...`);
+                await Promise.all(
+                    participantColRef.documents.map(async (participant) => {
+                        try {
+                            await databases.deleteDocument(
+                                process.env.MASTER_DATABASE_ID,
+                                process.env.PARTICIPANTS_COLLECTION_ID,
+                                participant.$id
+                            );
+                        } catch (err) {
+                            if (err.code !== 404) throw err;
+                        }
+                    })
+                );
+            } else {
+                participantsDone = true;
+            }
         }
 
         // 2. Delete livekit room

--- a/functions/delete-room/src/main.js
+++ b/functions/delete-room/src/main.js
@@ -1,5 +1,5 @@
 import { Client, Databases, Query } from "node-appwrite";
-import { RoomServiceClient } from "livekit-server-sdk";
+import { RoomServiceClient, TwirpError } from "livekit-server-sdk";
 import { throwIfMissing } from "./utils.js";
 
 export default async ({ req, res, log, error }) => {
@@ -87,7 +87,7 @@ export default async ({ req, res, log, error }) => {
             await roomServiceClient.deleteRoom(appwriteRoomDocId);
         } catch (lkErr) {
             // If room not found in LiveKit, it might already be gone, which is fine
-            if (lkErr.message?.includes("not found")) {
+            if (lkErr instanceof TwirpError && lkErr.code === "not_found") {
                 log("LiveKit room already deleted or not found.");
             } else {
                 throw lkErr;

--- a/functions/delete-room/src/main.js
+++ b/functions/delete-room/src/main.js
@@ -50,30 +50,46 @@ export default async ({ req, res, log, error }) => {
             return res.json({ msg: "User is not room admin" }, 403);
         }
 
-        //Delete Appwrite room doc
+        // 1. Removing participants from collection
+        const participantColRef = await databases.listDocuments(
+            process.env.MASTER_DATABASE_ID,
+            process.env.PARTICIPANTS_COLLECTION_ID,
+            [Query.equal("roomId", [appwriteRoomDocId])]
+        );
+        
+        log(`Found ${participantColRef.documents.length} participants to remove.`);
+        
+        if (participantColRef.documents.length > 0) {
+            await Promise.all(
+                participantColRef.documents.map((participant) =>
+                    databases.deleteDocument(
+                        process.env.MASTER_DATABASE_ID,
+                        process.env.PARTICIPANTS_COLLECTION_ID,
+                        participant.$id
+                    )
+                )
+            );
+        }
+
+        // 2. Delete livekit room
+        try {
+            await roomServiceClient.deleteRoom(appwriteRoomDocId);
+        } catch (lkErr) {
+            // If room not found in LiveKit, it might already be gone, which is fine
+            if (lkErr.message?.includes("not found")) {
+                log("LiveKit room already deleted or not found.");
+            } else {
+                throw lkErr;
+            }
+        }
+
+        // 3. Delete Appwrite room doc (Final step to ensure atomicity in reconciliation)
         await databases.deleteDocument(
             process.env.MASTER_DATABASE_ID,
             process.env.ROOMS_COLLECTION_ID,
             appwriteRoomDocId
         );
 
-        // Removing participants from collection
-        const participantColRef = await databases.listDocuments(
-            process.env.MASTER_DATABASE_ID,
-            process.env.PARTICIPANTS_COLLECTION_ID,
-            [Query.equal("roomId", [appwriteRoomDocId])]
-        );
-        log(participantColRef);
-        participantColRef.documents.forEach(async (participant) => {
-            await databases.deleteDocument(
-                process.env.MASTER_DATABASE_ID,
-                process.env.PARTICIPANTS_COLLECTION_ID,
-                participant.$id
-            );
-        });
-
-        // Delete livekit room
-        await roomServiceClient.deleteRoom(appwriteRoomDocId);
         return res.json({ msg: "Room deleted successfully" });
     } catch (e) {
         error(String(e));

--- a/functions/livekit-webhook/src/appwrite.js
+++ b/functions/livekit-webhook/src/appwrite.js
@@ -1,4 +1,4 @@
-import { Client, Databases } from 'node-appwrite';
+import { Client, Databases, Query } from 'node-appwrite';
 
 class AppwriteService {
     constructor() {
@@ -22,32 +22,43 @@ class AppwriteService {
             );
             return true;
         } catch (err) {
-            if (err.code !== 404) throw err;
+            if (err.code !== 404) {
+                console.error(`Error checking room existence: ${err.message}`);
+            }
             return false;
         }
     }
 
     async deleteRoom(roomId) {
-        // Deleting room doc inside rooms collection in master database
-        await this.databases.deleteDocument(
-            process.env.MASTER_DATABASE_ID,
-            process.env.ROOMS_COLLECTION_ID,
-            roomId
-        );
-
-        // Removing participants from collection
+        // 1. Removing participants from collection
         const participantColRef = await this.databases.listDocuments(
             process.env.MASTER_DATABASE_ID,
             process.env.PARTICIPANTS_COLLECTION_ID,
             [Query.equal('roomId', [roomId])]
         );
-        participantColRef.documents.forEach(async (participant) => {
+
+        if (participantColRef.documents.length > 0) {
+            await Promise.all(
+                participantColRef.documents.map((participant) =>
+                    this.databases.deleteDocument(
+                        process.env.MASTER_DATABASE_ID,
+                        process.env.PARTICIPANTS_COLLECTION_ID,
+                        participant.$id
+                    )
+                )
+            );
+        }
+
+        // 2. Deleting room doc inside rooms collection in master database
+        try {
             await this.databases.deleteDocument(
                 process.env.MASTER_DATABASE_ID,
-                process.env.PARTICIPANTS_COLLECTION_ID,
-                participant.$id
+                process.env.ROOMS_COLLECTION_ID,
+                roomId
             );
-        });
+        } catch (err) {
+            if (err.code !== 404) throw err;
+        }
     }
 }
 

--- a/functions/livekit-webhook/src/appwrite.js
+++ b/functions/livekit-webhook/src/appwrite.js
@@ -22,9 +22,7 @@ class AppwriteService {
             );
             return true;
         } catch (err) {
-            if (err.code !== 404) {
-                console.error(`Error checking room existence: ${err.message}`);
-            }
+            if (err.code !== 404) throw err;
             return false;
         }
     }

--- a/functions/livekit-webhook/src/appwrite.js
+++ b/functions/livekit-webhook/src/appwrite.js
@@ -30,23 +30,36 @@ class AppwriteService {
     }
 
     async deleteRoom(roomId) {
-        // 1. Removing participants from collection
-        const participantColRef = await this.databases.listDocuments(
-            process.env.MASTER_DATABASE_ID,
-            process.env.PARTICIPANTS_COLLECTION_ID,
-            [Query.equal('roomId', [roomId])]
-        );
-
-        if (participantColRef.documents.length > 0) {
-            await Promise.all(
-                participantColRef.documents.map((participant) =>
-                    this.databases.deleteDocument(
-                        process.env.MASTER_DATABASE_ID,
-                        process.env.PARTICIPANTS_COLLECTION_ID,
-                        participant.$id
-                    )
-                )
+        // 1. Removing participants from collection (with pagination)
+        let done = false;
+        while (!done) {
+            const participantColRef = await this.databases.listDocuments(
+                process.env.MASTER_DATABASE_ID,
+                process.env.PARTICIPANTS_COLLECTION_ID,
+                [
+                    Query.equal('roomId', [roomId]),
+                    Query.limit(50)
+                ]
             );
+
+            if (participantColRef.documents.length > 0) {
+                await Promise.all(
+                    participantColRef.documents.map(async (participant) => {
+                        try {
+                            await this.databases.deleteDocument(
+                                process.env.MASTER_DATABASE_ID,
+                                process.env.PARTICIPANTS_COLLECTION_ID,
+                                participant.$id
+                            );
+                        } catch (err) {
+                            // Ignore 404 as it means it was already deleted
+                            if (err.code !== 404) throw err;
+                        }
+                    })
+                );
+            } else {
+                done = true;
+            }
         }
 
         // 2. Deleting room doc inside rooms collection in master database

--- a/functions/livekit-webhook/src/main.js
+++ b/functions/livekit-webhook/src/main.js
@@ -30,9 +30,10 @@ export default async (context) => {
             const appwriteRoomDocId = event.room.name;
 
             // Delete the room in appwrite if it still exists
-            log(appwrite.doesRoomExist(appwriteRoomDocId));
-            if (appwrite.doesRoomExist(appwriteRoomDocId)) {
-                appwrite.deleteRoom(appwriteRoomDocId);
+            const exists = await appwrite.doesRoomExist(appwriteRoomDocId);
+            log(`Room exists: ${exists}`);
+            if (exists) {
+                await appwrite.deleteRoom(appwriteRoomDocId);
             }
         }
     } catch (e) {


### PR DESCRIPTION
Fixes #152

This PR implements the fixes proposed in my issue regarding room deletion atomicity.

## Changes

- Replaced forEach with await Promise.all() in delete-room, livekit-webhook, and database-cleaner.
- Changed the deletion sequence to ensure the Appwrite Room document is deleted last, acting as a fallback for reconciliation.
- Added error handling for cases where LiveKit rooms might already be deleted.