### PR TITLE
fix: add room existence validation in join-room to prevent tokens for…

### DIFF
--- a/functions/join-room/package.json
+++ b/functions/join-room/package.json
@@ -9,7 +9,8 @@
         "format": "prettier --write ."
     },
     "dependencies": {
-        "livekit-server-sdk": "^1.2.6"
+        "livekit-server-sdk": "^1.2.6",
+        "node-appwrite": "^17.0.0"
     },
     "devDependencies": {
         "prettier": "^3.0.0"

--- a/functions/join-room/src/appwrite.js
+++ b/functions/join-room/src/appwrite.js
@@ -1,0 +1,31 @@
+import { Client, Databases } from 'node-appwrite';
+
+class AppwriteService {
+    constructor() {
+        const client = new Client();
+        client
+            .setEndpoint(
+                process.env.APPWRITE_ENDPOINT ?? 'https://cloud.appwrite.io/v1'
+            )
+            .setProject(process.env.APPWRITE_FUNCTION_PROJECT_ID)
+            .setKey(process.env.APPWRITE_API_KEY);
+
+        this.databases = new Databases(client);
+    }
+
+    async doesRoomExist(roomId) {
+        try {
+            await this.databases.getDocument(
+                process.env.MASTER_DATABASE_ID,
+                process.env.ROOMS_COLLECTION_ID,
+                roomId
+            );
+            return true;
+        } catch (err) {
+            if (err.code !== 404) throw err;
+            return false;
+        }
+    }
+}
+
+export default AppwriteService;

--- a/functions/join-room/src/main.js
+++ b/functions/join-room/src/main.js
@@ -1,12 +1,18 @@
+import AppwriteService from "./appwrite.js";
 import { generateToken } from "./livekit.js";
 import { throwIfMissing } from "./utils.js";
 
 export default async ({ req, res, log, error }) => {
     throwIfMissing(process.env, [
+        "APPWRITE_API_KEY",
+        "MASTER_DATABASE_ID",
+        "ROOMS_COLLECTION_ID",
         "LIVEKIT_API_KEY",
         "LIVEKIT_API_SECRET",
         "LIVEKIT_SOCKET_URL",
     ]);
+
+    const appwrite = new AppwriteService();
 
     try {
         throwIfMissing(JSON.parse(req.body), ["roomName", "uid"]);
@@ -17,6 +23,13 @@ export default async ({ req, res, log, error }) => {
     try {
         log(req);
         const { roomName, uid: userId } = JSON.parse(req.body);
+
+        // Verify room exists before generating token
+        const roomExists = await appwrite.doesRoomExist(roomName);
+        if (!roomExists) {
+            log(`Room not found: ${roomName}`);
+            return res.json({ msg: "Room not found" }, 404);
+        }
 
         const accessToken = generateToken(process.env, roomName, userId, false);
 


### PR DESCRIPTION
Fixes #154

## Problem
The join-room function generated LiveKit tokens without verifying room existence, allowing users to receive tokens for non-existent or deleted rooms.

## Changes
- Added AppwriteService to validate room existence before token generation
- Returns 404 error with clear message if room not found
- Added required environment variables (APPWRITE_API_KEY, MASTER_DATABASE_ID, ROOMS_COLLECTION_ID)
- Follows error handling pattern from other functions

## Testing
**Code Review:**
- Room validation logic added before token generation
- Returns 404 for non-existent rooms
- Follows same pattern as delete-room function
- Error handling properly rethrows non-404 errors

**Integration Testing:**
Requires deployment to Appwrite instance for full testing. Suggested test cases:
1. Valid room ID → Should return 200 with access token
2. Non-existent room ID → Should return 404 with "Room not found"
3. Deleted room ID → Should return 404 with "Room not found"

I don't have access to the Appwrite deployment environment, but I'm happy to make any adjustments based on your testing feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend verification to check room existence before issuing access tokens
* **Bug Fixes**
  * Validate room exists before generating tokens
  * Returns "Room not found" when attempting to access a non-existent room
* **Chores**
  * Introduced a backend integration and added runtime configuration checks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->