### PR TITLE
fix(#142): Add missing await keywords in livekit webhook room cleanup

### DIFF
--- a/functions/livekit-webhook/src/main.js
+++ b/functions/livekit-webhook/src/main.js
@@ -30,10 +30,11 @@ export default async (context) => {
             const appwriteRoomDocId = event.room.name;
 
             // Delete the room in appwrite if it still exists
-log(await appwrite.doesRoomExist(appwriteRoomDocId));
-  if (await appwrite.doesRoomExist(appwriteRoomDocId)) {                appwrite.deleteRoom(appwriteRoomDocId);
-            }
+            const roomExists = await appwrite.doesRoomExist(appwriteRoomDocId);
+            log(`Room ${appwriteRoomDocId} exists: ${roomExists}`);
+            if (roomExists) {
                 await appwrite.deleteRoom(appwriteRoomDocId);
+            }
         }
     } catch (e) {
         error(String(e));

--- a/functions/livekit-webhook/src/main.js
+++ b/functions/livekit-webhook/src/main.js
@@ -26,12 +26,11 @@ export default async (context) => {
         log(event);
 
         if (event.event === 'room_finished') {
-            // Appwrite room id is same as Livekit room name
             const appwriteRoomDocId = event.room.name;
 
-            // Delete the room in appwrite if it still exists
             const roomExists = await appwrite.doesRoomExist(appwriteRoomDocId);
             log(`Room ${appwriteRoomDocId} exists: ${roomExists}`);
+
             if (roomExists) {
                 await appwrite.deleteRoom(appwriteRoomDocId);
             }

--- a/functions/livekit-webhook/src/main.js
+++ b/functions/livekit-webhook/src/main.js
@@ -30,10 +30,10 @@ export default async (context) => {
             const appwriteRoomDocId = event.room.name;
 
             // Delete the room in appwrite if it still exists
-            log(appwrite.doesRoomExist(appwriteRoomDocId));
-            if (appwrite.doesRoomExist(appwriteRoomDocId)) {
-                appwrite.deleteRoom(appwriteRoomDocId);
+log(await appwrite.doesRoomExist(appwriteRoomDocId));
+  if (await appwrite.doesRoomExist(appwriteRoomDocId)) {                appwrite.deleteRoom(appwriteRoomDocId);
             }
+                await appwrite.deleteRoom(appwriteRoomDocId);
         }
     } catch (e) {
         error(String(e));


### PR DESCRIPTION
This commit fixes issue #142 by adding missing 'await' keywords to async function calls in the livekit-webhook room cleanup handler.

Changes made:
- Added 'await' to appwrite.doesRoomExist() call in log statement
- Added 'await' to appwrite.doesRoomExist() call in if condition
- Added 'await' to appwrite.deleteRoom() call

This ensures proper synchronization of asynchronous database operations and prevents race conditions where the function may return before cleanup completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook processing reliability by verifying room existence before deletion, ensuring deletions occur only after confirmation and reducing race conditions.
  * Ensured deletion steps complete before proceeding, preventing incomplete or inconsistent operations in live collaboration sessions.
  * Updated logs to clearly reflect verification results and deletion actions for better operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->