### PR TITLE
feat: add delete-account Cloud Function for permanent user auth deletion (#758)

### DIFF
--- a/appwrite.json
+++ b/appwrite.json
@@ -515,6 +515,31 @@
             "entrypoint": "src/main.js",
             "commands": "npm install",
             "path": "functions/sync-all-documents-with-meilisearch"
+        },
+        {
+            "$id": "delete-account",
+            "name": "Delete Account",
+            "runtime": "node-16.0",
+            "path": "functions/delete-account",
+            "entrypoint": "src/main.js",
+            "ignore": [
+                "node_modules",
+                ".npm"
+            ],
+            "vars": [],
+            "execute": [
+                "users"
+            ],
+            "events": [],
+            "schedule": "",
+            "timeout": 15,
+            "commands": "npm install",
+            "enabled": true,
+            "logging": true,
+            "scopes": [
+                "users.read",
+                "users.write"
+            ]
         }
     ],
     "buckets": [

--- a/functions/delete-account/package.json
+++ b/functions/delete-account/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "delete-account",
+    "version": "1.0.0",
+    "description": "",
+    "main": "src/main.js",
+    "type": "module",
+    "scripts": {
+        "start": "node src/main.js",
+        "format": "prettier --write ."
+    },
+    "dependencies": {
+        "node-appwrite": "^17.0.0"
+    },
+    "devDependencies": {
+        "prettier": "^3.0.0"
+    }
+}

--- a/functions/delete-account/src/main.js
+++ b/functions/delete-account/src/main.js
@@ -1,0 +1,38 @@
+import { Client, Users } from 'node-appwrite';
+import { throwIfMissing } from './utils.js';
+
+export default async ({ req, res, log, error }) => {
+    throwIfMissing(process.env, ['APPWRITE_API_KEY']);
+
+    // Appwrite automatically sets x-appwrite-user-id when an authenticated
+    // user invokes a function — use this to ensure users can only delete
+    // their own account.
+    const userId = req.headers['x-appwrite-user-id'];
+    if (!userId) {
+        return res.json({ message: 'Unauthorized: no user session found' }, 401);
+    }
+
+    const client = new Client()
+        .setEndpoint(
+            process.env.APPWRITE_ENDPOINT ?? 'https://cloud.appwrite.io/v1'
+        )
+        .setProject(process.env.APPWRITE_FUNCTION_PROJECT_ID)
+        .setKey(process.env.APPWRITE_API_KEY);
+
+    try {
+        log(`Deleting auth account for user: ${userId}`);
+
+        // Hard-delete the Appwrite auth account. This is only possible
+        // server-side via the Users API — the client SDK has no equivalent.
+        // The client-side already handles: profile picture, user doc,
+        // username doc. Appwrite cascade relationships handle: followers, friends.
+        await new Users(client).deleteUser(userId);
+
+        log(`Auth account deleted successfully for user: ${userId}`);
+    } catch (e) {
+        error(String(e));
+        return res.json({ message: String(e) }, 500);
+    }
+
+    return res.json({ message: 'Account permanently deleted' });
+};

--- a/functions/delete-account/src/utils.js
+++ b/functions/delete-account/src/utils.js
@@ -1,0 +1,11 @@
+export const throwIfMissing = (obj, keys) => {
+    const missing = [];
+    for (let key of keys) {
+        if (!(key in obj) || !obj[key]) {
+            missing.push(key);
+        }
+    }
+    if (missing.length > 0) {
+        throw new Error(`Missing required fields: ${missing.join(', ')}`);
+    }
+};


### PR DESCRIPTION
## Summary

Fixes #758 — Account Deletion Does Not Permanently Remove User Data.

The Appwrite client SDK has no hard-delete endpoint for auth accounts. Without a server-side call, the auth record persists indefinitely even after the user's profile data is removed, meaning the user could theoretically re-authenticate with old credentials or the account occupies space in the system.

This PR adds a new `delete-account` Cloud Function that calls the Appwrite **Users API** (`users.deleteUser`) server-side to permanently and irreversibly remove the auth account.

## What this PR does

- Adds `functions/delete-account/` with `src/main.js`, `src/utils.js`, and `package.json`
- Registers the function in `appwrite.json` with `users.read` + `users.write` scopes
- The function reads `x-appwrite-user-id` from the request header (set automatically by Appwrite for authenticated invocations) — ensuring a user can only delete their own account
- Returns `401` if no authenticated user is present, `500` on Appwrite error, `200` on success

## Deletion flow (end-to-end)

The Flutter client (see related PR) handles:
1. Delete profile picture from `user-images` storage bucket
2. Delete username document from `usernames` collection
3. Delete user profile document from `users` collection
4. Invoke this Cloud Function → **hard-deletes the auth account**
5. Call `account.deleteSessions()` to invalidate any remaining tokens
6. Navigate to welcome screen

Appwrite cascade relationships automatically handle deletion of `followers` and `friends` sub-documents.

## Related

- Flutter app PR: https://github.com/AOSSIE-Org/Resonate/pull/786
- Issue: #758