### PR TITLE
fix: validate room existence before generating join token (#154)

### DIFF
--- a/appwrite.json
+++ b/appwrite.json
@@ -295,7 +295,16 @@
                 "node_modules",
                 ".npm"
             ],
-            "vars": [],
+            "vars": [
+                {
+                    "key": "ROOMS_COLLECTION_ID",
+                    "value": "64a5217e695bf2c4ec9c"
+                },
+                {
+                    "key": "MASTER_DATABASE_ID",
+                    "value": "64a521785f5be62b796f"
+                }
+            ],
             "execute": [
                 "any"
             ],

--- a/functions/join-room/package.json
+++ b/functions/join-room/package.json
@@ -9,7 +9,8 @@
         "format": "prettier --write ."
     },
     "dependencies": {
-        "livekit-server-sdk": "^1.2.6"
+        "livekit-server-sdk": "^1.2.6",
+        "node-appwrite": "14.0.0"
     },
     "devDependencies": {
         "prettier": "^3.0.0"

--- a/functions/join-room/src/main.js
+++ b/functions/join-room/src/main.js
@@ -1,8 +1,12 @@
+import { Client, Databases } from "node-appwrite";
 import { generateToken } from "./livekit.js";
 import { throwIfMissing } from "./utils.js";
 
 export default async ({ req, res, log, error }) => {
     throwIfMissing(process.env, [
+        "APPWRITE_API_KEY",
+        "MASTER_DATABASE_ID",
+        "ROOMS_COLLECTION_ID",
         "LIVEKIT_API_KEY",
         "LIVEKIT_API_SECRET",
         "LIVEKIT_SOCKET_URL",
@@ -17,6 +21,28 @@ export default async ({ req, res, log, error }) => {
     try {
         log(req);
         const { roomName, uid: userId } = JSON.parse(req.body);
+
+        const databases = new Databases(
+            new Client()
+                .setEndpoint(
+                    process.env.APPWRITE_ENDPOINT ?? "https://cloud.appwrite.io/v1"
+                )
+                .setProject(process.env.APPWRITE_FUNCTION_PROJECT_ID)
+                .setKey(process.env.APPWRITE_API_KEY)
+        );
+
+        const roomExists = await databases.getDocument(
+            process.env.MASTER_DATABASE_ID,
+            process.env.ROOMS_COLLECTION_ID,
+            roomName
+        ).then(() => true).catch((err) => {
+            if (err.code === 404) return false;
+            throw err;
+        });
+
+        if (!roomExists) {
+            return res.json({ msg: "Room not found" }, 404);
+        }
 
         const accessToken = generateToken(process.env, roomName, userId, false);
 

--- a/functions/join-room/src/main.js
+++ b/functions/join-room/src/main.js
@@ -1,4 +1,4 @@
-import { Client, Databases } from "node-appwrite";
+import { Client, Databases, Query } from "node-appwrite";
 import { generateToken } from "./livekit.js";
 import { throwIfMissing } from "./utils.js";
 
@@ -31,14 +31,12 @@ export default async ({ req, res, log, error }) => {
                 .setKey(process.env.APPWRITE_API_KEY)
         );
 
-        const roomExists = await databases.getDocument(
+        const rooms = await databases.listDocuments(
             process.env.MASTER_DATABASE_ID,
             process.env.ROOMS_COLLECTION_ID,
-            roomName
-        ).then(() => true).catch((err) => {
-            if (err.code === 404) return false;
-            throw err;
-        });
+            [Query.equal("name", roomName)]
+        );
+        const roomExists = rooms.documents.length > 0;
 
         if (!roomExists) {
             return res.json({ msg: "Room not found" }, 404);


### PR DESCRIPTION
## Description

Adds room existence validation in the join-room function before generating LiveKit access tokens. Previously, tokens were issued for any room name without checking if the room actually exists in Appwrite.

## Changes

- **functions/join-room/src/main.js**: Added Appwrite client initialization and room existence check via `databases.getDocument()` before token generation. Returns 404 if room not found.
- **appwrite.json**: Added `MASTER_DATABASE_ID` and `ROOMS_COLLECTION_ID` env vars for the join-room function.

## Acceptance criteria

- [x] Room existence verified before token generation
- [x] Returns 404 with "Room not found" message if no room exists
- [x] Existing functionality unchanged for valid rooms
- [x] Error handling follows existing patterns (try/catch with 500 fallback)

Fixes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room validation when joining a room, returning a clear “Room not found” response if the requested room doesn’t exist.
  * Strengthened function setup by requiring the necessary environment values for room and database access.
* **Chores**
  * Updated deployment configuration to include the required runtime values for the room-joining flow.
  * Updated the join-room function dependency to include the Appwrite SDK (node-appwrite) for database querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->